### PR TITLE
Fix: ruby app fails to push

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
-ruby '2.1.5'
+ruby '2.1.7'
 gem 'sinatra'
 gem 'thin'


### PR DESCRIPTION
Update gemfile to use ruby version 2.1.7.

As of v1.6.4 of the [buildpack](https://github.com/cloudfoundry/ruby-buildpack/releases) (Aug 2015), ruby 2.1.5 support has been removed
